### PR TITLE
Javascriptありでの商品画像の投稿 

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,9 +3,7 @@ class ItemsController < ApplicationController
   
   def new
     @item = Item.new
-    3.times do
-      @item.images.build
-    end
+    @item.images.build
     render layout: 'no_menu'
   end
 

--- a/app/javascript/item_form.js
+++ b/app/javascript/item_form.js
@@ -1,0 +1,29 @@
+document.addEventListener('turbolinks:load', function () {
+  //新規画像投稿用のfile_fieldを作成しappendする。
+  function newFileField(index) {
+    const html = `
+               <input accept="image/*" class="new-item-image" style="display: block;" data-index="${index}" type="file" name="item[images_attributes][${index}][src]" id="item_images_attributes_${index}_src">
+               `;
+    return html;
+  }
+  if (!$('#item_form')[0]) return false;
+  //商品出品・編集ページではないなら以降実行しない。
+  $("#select-image-button").on("click", function () {
+    const file_field = $(".new-item-image:last"); // 新規画像投稿用のfile_fieldのを取得する。
+    file_field.trigger("click"); // file_fieldをクリックさせる。
+  });
+  $("#image-file-fields").on("change", `input[type="file"]`, function (e) { //新しく画像が選択された、もしくは変更しようとしたが何も選択しなかった時
+    console.table(e.target.files);
+    console.log("画像が選択されました")
+    const file = e.target.files[0];
+    let index = $(this).data("index");
+    console.log("選択した画像のindex=", index);
+    const blob_url = window.URL.createObjectURL(file); //選択された画像をblob url形式に変換する。
+    console.log(blob_url);
+    const preview_html = `<img src="${blob_url}" width="20%">`;
+    $("#select-image-button").before(preview_html);
+    index += 1;
+    const file_field_html = newFileField(index);
+    $("#image-file-fields").append(file_field_html);
+  });
+});

--- a/app/javascript/item_form.js
+++ b/app/javascript/item_form.js
@@ -17,14 +17,10 @@ document.addEventListener('turbolinks:load', function () {
   });
   //新しく画像が選択された、もしくは変更しようとしたが何も選択しなかった時
   $("#image-file-fields").on("change", `input[type="file"]`, function (e) { 
-    console.table(e.target.files);
-    console.log("画像が選択されました")
     const file = e.target.files[0];
     let index = $(this).data("index");
-    console.log("選択した画像のindex=", index);
     //選択された画像をblob url形式に変換する。
     const blob_url = window.URL.createObjectURL(file); 
-    console.log(blob_url);
     const preview_html = `<img src="${blob_url}" width="20%">`;
     $("#select-image-button").before(preview_html);
     index += 1;

--- a/app/javascript/item_form.js
+++ b/app/javascript/item_form.js
@@ -1,3 +1,4 @@
+//復習用にコメントアウトを残しておきます。 
 document.addEventListener('turbolinks:load', function () {
   //新規画像投稿用のfile_fieldを作成しappendする。
   function newFileField(index) {
@@ -9,16 +10,20 @@ document.addEventListener('turbolinks:load', function () {
   if (!$('#item_form')[0]) return false;
   //商品出品・編集ページではないなら以降実行しない。
   $("#select-image-button").on("click", function () {
-    const file_field = $(".new-item-image:last"); // 新規画像投稿用のfile_fieldのを取得する。
-    file_field.trigger("click"); // file_fieldをクリックさせる。
+    // 新規画像投稿用のfile_fieldのを取得する。
+    const file_field = $(".new-item-image:last"); 
+    // file_fieldをクリックさせる。
+    file_field.trigger("click"); 
   });
-  $("#image-file-fields").on("change", `input[type="file"]`, function (e) { //新しく画像が選択された、もしくは変更しようとしたが何も選択しなかった時
+  //新しく画像が選択された、もしくは変更しようとしたが何も選択しなかった時
+  $("#image-file-fields").on("change", `input[type="file"]`, function (e) { 
     console.table(e.target.files);
     console.log("画像が選択されました")
     const file = e.target.files[0];
     let index = $(this).data("index");
     console.log("選択した画像のindex=", index);
-    const blob_url = window.URL.createObjectURL(file); //選択された画像をblob url形式に変換する。
+    //選択された画像をblob url形式に変換する。
+    const blob_url = window.URL.createObjectURL(file); 
     console.log(blob_url);
     const preview_html = `<img src="${blob_url}" width="20%">`;
     $("#select-image-button").before(preview_html);

--- a/app/javascript/jquery.js
+++ b/app/javascript/jquery.js
@@ -1,0 +1,1 @@
+import "./item_form"

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -28,7 +28,7 @@
         %br
         = image.object.src
         %br
-        = image.file_field :src, accept: "image/*"
+        = image.file_field :src, accept: "image/*", class: "new-item-image", style: "display: block;", data: {index: image.index}
         - if image.object.persisted?
           = image.check_box :_destroy, include_hidden: false, style: "display: block;"
     .error-field{data:{column_name: "item_images"}}


### PR DESCRIPTION
#What
Javascriptを使い、出品/編集時の商品画像のプレビューを表示

#Why
同期通信ではプレビュー表示ができず、その場で追加/削除をすることが難しい。