### PR TITLE
Edit item's images by js

### DIFF
--- a/app/javascript/item_form.js
+++ b/app/javascript/item_form.js
@@ -38,7 +38,12 @@ document.addEventListener('turbolinks:load', function () {
     let index = $(this).data("index");
     //選択された画像をblob url形式に変換する。
     const blob_url = window.URL.createObjectURL(file); 
-    const preview_html = `<img src="${blob_url}" width="20%">`;
+    if ($(`.item-image[data-index="${index}"]`)[0]) {
+      const preview_image = $(`.item-image[data-index="${index}"]`).children("img");
+      preview_image.attr("src", blob_url);
+      return false;
+    }
+    const preview_html = buildImagePreview(blob_url, index);
     $("#select-image-button").before(preview_html);
     index += 1;
     const file_field_html = newFileField(index);

--- a/app/javascript/item_form.js
+++ b/app/javascript/item_form.js
@@ -37,6 +37,11 @@ document.addEventListener('turbolinks:load', function () {
   $("#image-file-fields").on("change", `input[type="file"]`, function (e) { 
     const file = e.target.files[0];
     let index = $(this).data("index");
+    if (!file) {
+      const delete_button = $(`.item-image[data-index="${index}"]`).find(".item-image__buttons--delete");
+      delete_button.trigger("click");
+      return false;
+    }
     //選択された画像をblob url形式に変換する。
     const blob_url = window.URL.createObjectURL(file); 
     if ($(`.item-image[data-index="${index}"]`)[0]) {

--- a/app/javascript/item_form.js
+++ b/app/javascript/item_form.js
@@ -50,4 +50,8 @@ document.addEventListener('turbolinks:load', function () {
     $(`#item_images_attributes_${index}__destroy`).prop("checked", true);
     $(`#item_images_attributes_${index}_src`).remove();
   });
+  $("#selected-item-images").on("click",".item-image__buttons--edit",function(e){
+    const index = $(this).parents(".item-image").data("index");
+    $(`#item_images_attributes_${index}_src`).trigger("click");
+  });
 });

--- a/app/javascript/item_form.js
+++ b/app/javascript/item_form.js
@@ -19,8 +19,9 @@ document.addEventListener('turbolinks:load', function () {
 
   //新規画像投稿用のfile_fieldを作成しappendする。
   function newFileField(index) {
+    // style="display: blockを追加するとファイルフィールド現れる。
     const html = `
-               <input accept="image/*" class="new-item-image" style="display: block;" data-index="${index}" type="file" name="item[images_attributes][${index}][src]" id="item_images_attributes_${index}_src">
+               <input accept="image/*" class="new-item-image" data-index="${index}" type="file" name="item[images_attributes][${index}][src]" id="item_images_attributes_${index}_src">
                `;
     return html;
   }

--- a/app/javascript/item_form.js
+++ b/app/javascript/item_form.js
@@ -44,4 +44,10 @@ document.addEventListener('turbolinks:load', function () {
     const file_field_html = newFileField(index);
     $("#image-file-fields").append(file_field_html);
   });
+  $("#selected-item-images").on("click", ".item-image__buttons--delete", function (e) {
+    const index = $(this).parents(".item-image").data("index");
+    $(this).parents(".item-image").remove();
+    $(`#item_images_attributes_${index}__destroy`).prop("checked", true);
+    $(`#item_images_attributes_${index}_src`).remove();
+  });
 });

--- a/app/javascript/item_form.js
+++ b/app/javascript/item_form.js
@@ -1,5 +1,22 @@
 //復習用にコメントアウトを残しておきます。 
 document.addEventListener('turbolinks:load', function () {
+  function buildImagePreview(blob_url, index) { //選択した画像ファイルのプレビューを表示する。
+    html = `
+            <div class="item-image new" data-index=${index}>
+              <img src =${blob_url} class="item-image__image">
+              <div class="item-image__buttons">
+                <div class="item-image__buttons--edit">
+                編集
+                </div>
+                <div class="item-image__buttons--delete">
+                削除
+                </div>
+              </div>
+            </div>
+            `;
+    return html;
+  }
+
   //新規画像投稿用のfile_fieldを作成しappendする。
   function newFileField(index) {
     const html = `

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -12,14 +12,15 @@
         最大5枚までアップロードできます。
         #selected-item-images
           -# 商品編集の際はプレビューを表示
-          - if false
-            .item-image{data: {index: 0}}
-              = image_tag "", class: "item-image__image"
-              .item-image__buttons
-                .item-image__buttons--edit
-                  編集
-                .item-image__buttons--delete
-                  削除
+          - @item.images.each_with_index do |image, i|
+            -if image.persisted?
+              .item-image{data: {index: i}}
+                = image_tag image.src.url, class: "item-image__image"
+                .item-image__buttons
+                  .item-image__buttons--edit
+                    編集
+                  .item-image__buttons--delete
+                    削除
           #select-image-button
             #select-image-button__text
               クリックしてファイルをアップロード

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -26,14 +26,14 @@
               クリックしてファイルをアップロード
     #image-file-fields
       = f.fields_for :images do |image|
-        -# 以下を記述するとファイル名出現
+        -# ↓以下を記述するとファイル名出現
         -# %br
         -# = image.object.src
         -# %br
-        -# new-item-imageとdata-indexの間にstyle: "display: block;"を追加するとファイルフィールド出現
+        -# ↓new-item-imageとdata-indexの間にstyle: "display: block;"を追加するとファイルフィールド出現
         = image.file_field :src, accept: "image/*", class: "new-item-image", data: {index: image.index} 
         - if image.object.persisted?
-          -# style: "display: block;"を末尾に追加するとファイルフィールド出現
+          -# ↓style: "display: block;"を末尾に追加するとファイルフィールド出現
           = image.check_box :_destroy, include_hidden: false
     .error-field{data:{column_name: "item_images"}}
   .block.horizontal-padding-5

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -26,12 +26,15 @@
               クリックしてファイルをアップロード
     #image-file-fields
       = f.fields_for :images do |image|
-        %br
-        = image.object.src
-        %br
-        = image.file_field :src, accept: "image/*", class: "new-item-image", style: "display: block;", data: {index: image.index}
+        -# 以下を記述するとファイル名出現
+        -# %br
+        -# = image.object.src
+        -# %br
+        -# new-item-imageとdata-indexの間にstyle: "display: block;"を追加するとファイルフィールド出現
+        = image.file_field :src, accept: "image/*", class: "new-item-image", data: {index: image.index} 
         - if image.object.persisted?
-          = image.check_box :_destroy, include_hidden: false, style: "display: block;"
+          -# style: "display: block;"を末尾に追加するとファイルフィールド出現
+          = image.check_box :_destroy, include_hidden: false
     .error-field{data:{column_name: "item_images"}}
   .block.horizontal-padding-5
     .input-field


### PR DESCRIPTION
#What
JSで画像の編集/削除、即時プレビューをする機能を実装。
ファイルフィールドとEdit時のチェックボックスを削除。

#Why
画像ファイルの編集結果を同期なしに確認するため。
ファイルフィールドは実用上、不要なため。